### PR TITLE
Moving workspace

### DIFF
--- a/common/workspace.py
+++ b/common/workspace.py
@@ -39,6 +39,7 @@ import collections
 import ROOT
 
 from HiggsAnalysis.CombinedLimit.ModelTools import SafeWorkspaceImporter
+from parameters import *
 
 ROOT.gSystem.Load('libRooFit.so')
 ROOT.gSystem.Load('libRooFitCore.so')
@@ -47,61 +48,6 @@ ROOT.gSystem.Load('libRooFitCore.so')
 SMALLNUMBER = 1.e-3
 # ignore statistical uncertainties from bins with content less than the cutoff (relative to the total content of the sample)
 STATCUTOFF = 0.1
-
-##### PARAMETERS - EDIT THIS SECTION #####
-
-outname = '/local/yiiyama/exec/ws.root'
-sourcedir = '/data/t3home000/yiiyama/studies/monophoton/distributions'
-filename = '{region}_{distribution}.root'
-histname = '{distribution}-{process}'
-
-regions = ['monoph', 'monoel', 'monomu', 'diel', 'dimu']
-processes = ['data', 'efake', 'gjets', 'halo', 'hfake', 'minor', 'spike', 'vvg', 'wg', 'zg', 'gg', 'wjets', 'top', 'zjets']
-processes += ['dmv-500-1', 'dmv-1000-1', 'dmv-2000-1']
-distribution = 'phoPtHighMet'
-
-# Links between samples. List of tuples.
-# The first sample (=target) of the tuple is represented by (transfer factor) * (second sample (=source)).
-# In the fit, the normalization of the source and the transfer factors are allowed to float, with constraints
-# on the transfer factors.
-links = [
-    (('zg', 'diel'), ('zg', 'monoph')),
-    (('zg', 'dimu'), ('zg', 'monoph')),
-    (('wg', 'monoel'), ('wg', 'monoph')),
-    (('wg', 'monomu'), ('wg', 'monoph')),
-    (('zg', 'monoel'), ('zg', 'monoph')),
-    (('zg', 'monomu'), ('zg', 'monoph')),
-#    (('wg', 'monoph'), ('zg', 'monoph'))
-]
-
-# Sample with free normalization that are not involved in links.
-floats = []
-
-ignoredNuisances = {
-    ('zg', 'diel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # leptonVetoSF ignored because it's supposed to be present in both SR and CR but is missing from CR
-    ('zg', 'dimu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # minorPDF and minorQCDscale are on zg & wg because of a bug in plotconfig
-    ('wg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
-    ('wg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
-    ('zg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'],
-    ('zg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec']
-}
-
-# Artificial bin-to-bin decorrelation
-decorrelatedNuisances = [
-    'zgEWK',
-    'wgEWK'
-]
-
-# Partial correlation in ratios.
-# {(target, source, nuisance): correlation}
-partialCorrelation = {
-    (('wg', 'monoph'), ('zg', 'monoph'), 'vgQCDscale'): 0.8
-}
-
-# Nuisances affecting normalization only
-scaleNuisances = ['lumi', 'photonSF', 'customIDSF', 'leptonVetoSF', 'egFakerate', 'haloNorm', 'spikeNorm', 'minorQCDScale']
-
-##### PARAMETERS END #####
 
 workspace = ROOT.RooWorkspace('wspace')
 wsimport = SafeWorkspaceImporter(workspace)

--- a/monojet/fit/parameters.py
+++ b/monojet/fit/parameters.py
@@ -1,0 +1,50 @@
+outname = '/local/yiiyama/exec/ws.root'
+sourcedir = '/data/t3home000/yiiyama/studies/monophoton/distributions'
+filename = '{region}_{distribution}.root'
+histname = '{distribution}-{process}'
+
+regions = ['monoph', 'monoel', 'monomu', 'diel', 'dimu']
+processes = ['data', 'efake', 'gjets', 'halo', 'hfake', 'minor', 'spike', 'vvg', 'wg', 'zg', 'gg', 'wjets', 'top', 'zjets']
+processes += ['dmv-500-1', 'dmv-1000-1', 'dmv-2000-1']
+distribution = 'phoPtHighMet'
+
+# Links between samples. List of tuples.
+# The first sample (=target) of the tuple is represented by (transfer factor) * (second sample (=source)).
+# In the fit, the normalization of the source and the transfer factors are allowed to float, with constraints
+# on the transfer factors.
+links = [
+    (('zg', 'diel'), ('zg', 'monoph')),
+    (('zg', 'dimu'), ('zg', 'monoph')),
+    (('wg', 'monoel'), ('wg', 'monoph')),
+    (('wg', 'monomu'), ('wg', 'monoph')),
+    (('zg', 'monoel'), ('zg', 'monoph')),
+    (('zg', 'monomu'), ('zg', 'monoph')),
+#    (('wg', 'monoph'), ('zg', 'monoph'))
+]
+
+# Sample with free normalization that are not involved in links.
+floats = []
+
+ignoredNuisances = {
+    ('zg', 'diel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # leptonVetoSF ignored because it's supposed to be present in both SR and CR but is missing from CR
+    ('zg', 'dimu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # minorPDF and minorQCDscale are on zg & wg because of a bug in plotconfig
+    ('wg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
+    ('wg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
+    ('zg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'],
+    ('zg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec']
+}
+
+# Artificial bin-to-bin decorrelation
+decorrelatedNuisances = [
+    'zgEWK',
+    'wgEWK'
+]
+
+# Partial correlation in ratios.
+# {(target, source, nuisance): correlation}
+partialCorrelation = {
+    (('wg', 'monoph'), ('zg', 'monoph'), 'vgQCDscale'): 0.8
+}
+
+# Nuisances affecting normalization only
+scaleNuisances = ['lumi', 'photonSF', 'customIDSF', 'leptonVetoSF', 'egFakerate', 'haloNorm', 'spikeNorm', 'minorQCDScale']

--- a/monojet/fit/workspace.py
+++ b/monojet/fit/workspace.py
@@ -1,0 +1,1 @@
+../../common/workspace.py

--- a/monophoton/fit/parameters.py
+++ b/monophoton/fit/parameters.py
@@ -1,0 +1,50 @@
+outname = '/local/yiiyama/exec/ws.root'
+sourcedir = '/data/t3home000/yiiyama/studies/monophoton/distributions'
+filename = '{region}_{distribution}.root'
+histname = '{distribution}-{process}'
+
+regions = ['monoph', 'monoel', 'monomu', 'diel', 'dimu']
+processes = ['data', 'efake', 'gjets', 'halo', 'hfake', 'minor', 'spike', 'vvg', 'wg', 'zg', 'gg', 'wjets', 'top', 'zjets']
+processes += ['dmv-500-1', 'dmv-1000-1', 'dmv-2000-1']
+distribution = 'phoPtHighMet'
+
+# Links between samples. List of tuples.
+# The first sample (=target) of the tuple is represented by (transfer factor) * (second sample (=source)).
+# In the fit, the normalization of the source and the transfer factors are allowed to float, with constraints
+# on the transfer factors.
+links = [
+    (('zg', 'diel'), ('zg', 'monoph')),
+    (('zg', 'dimu'), ('zg', 'monoph')),
+    (('wg', 'monoel'), ('wg', 'monoph')),
+    (('wg', 'monomu'), ('wg', 'monoph')),
+    (('zg', 'monoel'), ('zg', 'monoph')),
+    (('zg', 'monomu'), ('zg', 'monoph')),
+#    (('wg', 'monoph'), ('zg', 'monoph'))
+]
+
+# Sample with free normalization that are not involved in links.
+floats = []
+
+ignoredNuisances = {
+    ('zg', 'diel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # leptonVetoSF ignored because it's supposed to be present in both SR and CR but is missing from CR
+    ('zg', 'dimu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'], # minorPDF and minorQCDscale are on zg & wg because of a bug in plotconfig
+    ('wg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
+    ('wg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'wgEWK', 'gec'],
+    ('zg', 'monoel'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec'],
+    ('zg', 'monomu'): ['leptonVetoSF', 'minorPDF', 'minorQCDscale', 'vgPDF', 'vgQCDscale', 'zgEWK', 'gec']
+}
+
+# Artificial bin-to-bin decorrelation
+decorrelatedNuisances = [
+    'zgEWK',
+    'wgEWK'
+]
+
+# Partial correlation in ratios.
+# {(target, source, nuisance): correlation}
+partialCorrelation = {
+    (('wg', 'monoph'), ('zg', 'monoph'), 'vgQCDscale'): 0.8
+}
+
+# Nuisances affecting normalization only
+scaleNuisances = ['lumi', 'photonSF', 'customIDSF', 'leptonVetoSF', 'egFakerate', 'haloNorm', 'spikeNorm', 'minorQCDScale']

--- a/monophoton/fit/workspace.py
+++ b/monophoton/fit/workspace.py
@@ -1,0 +1,1 @@
+../../common/workspace.py


### PR DESCRIPTION
@yiiyama How about we do something like this? I moved the workspace.py to common, and put the parameters in a separate module.

I couldn't get the diffs to work out nicely, but if you look at the two commits separately, it's much more useful.
